### PR TITLE
Added tab management commands, added keyword to actions

### DIFF
--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -260,11 +260,13 @@ var defaultSugestions = [
     },
     {
         "text": "Close Tabs To Right",
-        "action": closeTabsToRight
+        "action": closeTabsToRight,
+        "keyword": "right"
     },
     {
         "text": "Close Tabs To Left",
-        "action": closeTabsToLeft
+        "action": closeTabsToLeft,
+        "keyword": "left"
     },
     {
         "text": "Mute/Unmute Tab",

--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -165,6 +165,38 @@ function closeTabsToLeft(){
     });
 }
 
+function moveTabToStart(){
+  chrome.tabs.query({'active': true, 'windowId': chrome.windows.WINDOW_ID_CURRENT}, function (currentTab) {
+      currentTab = currentTab[0];
+      chrome.tabs.move(currentTab.id, { index: 0 });
+      window.close();
+  });
+}
+
+function moveTabToEnd(){
+  chrome.tabs.query({'active': true, 'windowId': chrome.windows.WINDOW_ID_CURRENT}, function (currentTab) {
+      currentTab = currentTab[0];
+      chrome.tabs.move(currentTab.id, { index: -1 });
+      window.close();
+  });
+}
+
+function moveTabLeft(){
+  chrome.tabs.query({'active': true, 'windowId': chrome.windows.WINDOW_ID_CURRENT}, function (currentTab) {
+      currentTab = currentTab[0];
+      chrome.tabs.move(currentTab.id, { index: currentTab.index - 1 });
+      window.close();
+  });
+}
+
+function moveTabRight(){
+  chrome.tabs.query({'active': true, 'windowId': chrome.windows.WINDOW_ID_CURRENT}, function (currentTab) {
+      currentTab = currentTab[0];
+      chrome.tabs.move(currentTab.id, { index: currentTab.index + 1 });
+      window.close();
+  });
+}
+
 var defaultSugestions = [
     {
         "text": "New Tab",
@@ -253,5 +285,21 @@ var defaultSugestions = [
     {
         "text": "Search IMDB",
         "action": triggerSearch("imdb")
+    },
+    {
+        "text": "Move Tab To Start",
+        "action": moveTabToStart
+    },
+    {
+        "text": "Move Tab To End",
+        "action": moveTabToEnd
+    },
+    {
+        "text": "Move Tab Left",
+        "action": moveTabLeft
+    },
+    {
+        "text": "Move Tab Right",
+        "action": moveTabRight
     }
 ];

--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -288,18 +288,22 @@ var defaultSugestions = [
     },
     {
         "text": "Move Tab To Start",
-        "action": moveTabToStart
+        "action": moveTabToStart,
+        "keyword": "move start"
     },
     {
         "text": "Move Tab To End",
-        "action": moveTabToEnd
+        "action": moveTabToEnd,
+        "keyword": 'move end'
     },
     {
         "text": "Move Tab Left",
-        "action": moveTabLeft
+        "action": moveTabLeft,
+        "keyword": 'move left'
     },
     {
         "text": "Move Tab Right",
-        "action": moveTabRight
+        "action": moveTabRight,
+        "keyword": 'move right'
     }
 ];

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -143,7 +143,7 @@ function populateSuggestionsBox(suggestionList){
 
 function fuzzySearch(){
     var options = {
-        keys: ['text']
+        keys: ['text', 'keyword']
     }
     var searchString = document.getElementById("command").value;
     if (searchString == ""){


### PR DESCRIPTION
Hi Sriram!

I've added a couple of commands for moving tabs around. I was contemplating a moveTabTo(i) command but that'd require significantly more time to develop - it'd need to work similarly to the search commands. 

I've also added a 'keyword' property to these commands and made Fuse use that keyword in its search. This is so I can just type "move start", or simply "start", to find the command I need. (Fuse's fuzzy search doesn't always find what I want based on the text.) If you like this, you might want to add a keyword to some of the others! Just give it some thought to make sure that it won't conflict with any of the existing commands and the things people are likely to type to find them. 
